### PR TITLE
コメント一覧機能(ツイート詳細画面時)

### DIFF
--- a/app/controllers/api/v1/tweets_controller.rb
+++ b/app/controllers/api/v1/tweets_controller.rb
@@ -44,6 +44,14 @@ module Api
         end
       end
 
+      def comments
+        tweet = Tweet.find(params[:id])
+        comments = Tweet.convert_hash_data(tweet.comment_tweets)
+
+        render json: { comments: },
+               status: :ok
+      end
+
       private
 
       def tweet_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
       namespace :auth do
         resources :users, only: %i[index]
       end
-      resources :tweets, only: %i[index show create destroy]
+      resources :tweets, only: %i[index show create destroy] do
+        member do
+          get :comments
+        end
+      end
       resources :comments, only: %i[create]
       resources :images, only: %i[update]
       mount_devise_token_auth_for 'User', at: 'users', controllers: {


### PR DESCRIPTION
## 課題のリンク

* [コメント一覧機能(ツイート詳細画面時)](https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#:~:text=%E3%81%A7%E5%AE%9F%E8%A3%85%E3%81%99%E3%82%8B-,%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E4%B8%80%E8%A6%A7%E6%A9%9F%E8%83%BD,-rails)

## やったこと

* コメント一覧機能(ツイート詳細画面時)の実装


## 動作確認方法

* コメント一覧機能(ツイート詳細画面)のSS
![リプライ](https://github.com/K-Akira928/twitter_rails_api/assets/134822923/f8457d23-1409-496d-b428-2c556628287d)

## その他

* 次のタスクにある [コメント削除API](https://github.com/happiness-chain/practice/blob/main/14.2_react/003_%E8%AA%B2%E9%A1%8C.md#:~:text=%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B-,rails(%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E5%89%8A%E9%99%A4API),-%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E3%81%AE%E5%89%8A%E9%99%A4) ですが、コメントにコメントできるようにする実装の関係上、既にコメント削除(本質的にはツイート削除)が機能する状態になっています。よって、このタスクでLGTMを頂いた場合コメント削除もLGTM頂いたと認識してもよろしいでしょうか。  
* rubocopのエラーに関してですが、`tweets_controller` の `comments` アクションが RESTfulに基づいていないアクションということで出ているエラーです。ロードマップの実装では `/api/v1/tweets/:tweet_id/comments` となっていましたので、ルーティングに `member` を用いて実装し、上記のようなエラーが発生している次第です。別途 `comments_controller` を作成し、RESTful に基づくアクションで作成する意図でしたら修正しますので指摘の程、よろしくお願いいたします。